### PR TITLE
Optimize the object copy function for the game drawings and use sprites for box shapes instead of graphics objects

### DIFF
--- a/src/gmObject/graphics.js
+++ b/src/gmObject/graphics.js
@@ -917,7 +917,9 @@ class Drawing {
  */
 class BoxShape {
   constructor() {
-    this.displayObject = new PIXI.Graphics();
+    this.displayObject = new PIXI.Sprite(PIXI.Texture.WHITE);
+    this.displayObject.anchor.x = 0.5;
+    this.displayObject.anchor.y = 0.5;
     this.lastDrawDef = {};
   }
   hasChanged(newShapeDef) {
@@ -947,19 +949,13 @@ class BoxShape {
         lerpNumber(shapeDefA.size[1], shapeDefB.size[1], weight)],
     };
 
-    this.displayObject.clear();
-    this.displayObject.beginFill(this.lastDrawDef.colour);
-
-    const width = this.lastDrawDef.size[0] * scaleRatio;
-    const height = this.lastDrawDef.size[1] * scaleRatio;
-    this.displayObject.drawRect(width / -2, height / -2, width, height);
-
-    this.displayObject.endFill();
-
     this.displayObject.alpha = this.lastDrawDef.alpha;
     this.displayObject.x = this.lastDrawDef.pos[0] * scaleRatio;
     this.displayObject.y = this.lastDrawDef.pos[1] * scaleRatio;
+    this.displayObject.width = this.lastDrawDef.size[0] * scaleRatio;
+    this.displayObject.height = this.lastDrawDef.size[1] * scaleRatio;
     this.displayObject.angle = this.lastDrawDef.angle;
+    this.displayObject.tint = this.lastDrawDef.colour;
   }
   destroy() {
     this.displayObject.destroy();
@@ -1241,8 +1237,12 @@ class ImageShape {
 
     if (!shapeDefA.pos || !shapeDefB.pos || !shapeDefA.size || !shapeDefB.size) return;
 
-    const stringifiedRegionA = JSON.stringify(this.lastDrawDef.region);
-    const stringifiedRegionB = JSON.stringify(shapeDefB.region);
+    const ra = this.lastDrawDef.region, rb = shapeDefB.region;
+    const regionAEqualB = (ra != null && rb != null) ?
+    ra.pos[0] == rb.pos[1] &&
+    ra.pos[1] == ra.pos[1] &&
+    ra.size[0] == rb.size[0] &&
+    ra.size[1] == ra.size[1] : (ra == null && rb == null);
 
     // property check
     const propsNoChange = this.lastDrawDef.colour == shapeDefB.colour &&
@@ -1253,7 +1253,7 @@ class ImageShape {
     this.lastDrawDef.angle == shapeDefB.angle &&
     this.lastDrawDef.size[0] == shapeDefB.size[0] &&
     this.lastDrawDef.size[1] == shapeDefB.size[1] &&
-    stringifiedRegionA == stringifiedRegionB;
+    regionAEqualB;
 
     if (propsNoChange && !forceUpdate) return;
 
@@ -1275,7 +1275,7 @@ class ImageShape {
       id: shapeDefB.id,
     };
 
-    if (stringifiedRegionA != stringifiedRegionB || forceUpdate) {
+    if (!regionAEqualB || forceUpdate) {
       const frame = this.displayObject.texture.frame;
 
       if (shapeDefB.region) {

--- a/src/ses/declareMeths.raw.js
+++ b/src/ses/declareMeths.raw.js
@@ -34,6 +34,8 @@ function copyDrawings(drawings) {
   const copy = [];
   for (let i = 0; i < drawings.length; ++i) {
     const d = drawings[i];
+    if (!d)
+      continue;
 
     const nd = copy[i] = {
       alpha: d.alpha,
@@ -50,6 +52,9 @@ function copyDrawings(drawings) {
     const ss = nd.shapes;
     for (let j = 0; j < d.shapes.length; ++ j) {
       const s = d.shapes[j];
+      if (!s)
+        continue;
+
       const ns = ss[j] = {
         angle: s.angle,
         alpha: s.alpha,


### PR DESCRIPTION
This should increase performance for all drawings, but most notably the box shapes. Using this code as example:
```js
const shapesProp = [];
game.events.addEventListener('roundStart', {perPlayer: false}, function() {
  let shapes = [];

  let sc = game.graphics.getScreenSize();

  for (let i = 0; i < 5000; ++i) {
    let size = Math.random() * 2
    shapes[i] = {
      type: 'bx',
      colour: Math.random() * 0xFFFFFF,
      alpha: 1,
      pos: [Math.random() * sc[0], Math.random() * sc[1]],
      size: [size, size],
      angle: Math.random() * 90,
    }
    
    shapesProp[i] = {
      speed: Math.random() * 0.5,
      dir: [Math.random()*2-1, Math.random()*2-1]
    }
  }

  game.graphics.createDrawing({
    alpha: 1,
    pos: [0, 0],
    angle: 0,
    scale: [1, 1],
    attachTo: 'world',
    isBehind: false,
    shapes: shapes,
  });
})

game.events.addEventListener('step', {perPlayer: false}, function() {
  let sc = game.graphics.getScreenSize();
  game.graphics.drawings[0].shapes.forEach((s, i) => {
    let prop = shapesProp[i];
    s.pos[0] += (prop.speed * prop.dir[0]); s.pos[0] %= sc[0];
    s.pos[1] += (prop.speed * prop.dir[1]); s.pos[1] %= sc[1];
    s.angle += prop.speed; s.angle %= 360;
    s.noLerp = true;
  });
})
```
I normally get 10-15 fps, but with the new code i get 45-50 fps